### PR TITLE
Raise Bento API error messages

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,10 @@
 AllCops:
   TargetRubyVersion: 2.6
+  NewCops: disable
+
+Naming/FileName:
+  Exclude:
+    - "lib/bento-actionmailer.rb"
 
 Style/StringLiterals:
   Enabled: true

--- a/lib/bento-actionmailer.rb
+++ b/lib/bento-actionmailer.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require "bento_actionmailer"

--- a/lib/bento_actionmailer.rb
+++ b/lib/bento_actionmailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bento_actionmailer/version"
 require "bento_actionmailer/railtie" if defined? Rails
 
@@ -6,6 +8,7 @@ require "net/http"
 require "uri"
 
 module BentoActionMailer
+  # Action Mailer delivery method that sends emails through Bento's batch email API.
   class DeliveryMethod
     class DeliveryError < StandardError; end
 
@@ -22,7 +25,7 @@ module BentoActionMailer
     end
 
     def deliver!(mail)
-      html_body = mail.body.parts.find { |p| p.content_type =~ /text\/html/ }
+      html_body = mail.body.parts.find { |p| p.content_type =~ %r{text/html} }
       raise DeliveryError, "No HTML body given. Bento requires an html email body." unless html_body
 
       send_mail(
@@ -37,37 +40,60 @@ module BentoActionMailer
     private
 
     def send_mail(to:, from:, subject:, html_body:, personalization: {})
-      import_data = [
-        {
-          to: to,
-          from: from,
-          subject: subject,
-          html_body: html_body,
-          transactional: settings[:transactional],
-          personalizations: personalization
-        }
-      ]
+      request = build_request(
+        to: to,
+        from: from,
+        subject: subject,
+        html_body: html_body,
+        personalization: personalization
+      )
+      handle_response(perform_request(request))
+    end
 
+    def build_request(to:, from:, subject:, html_body:, personalization:)
       request = Net::HTTP::Post.new(BENTO_ENDPOINT)
       request.basic_auth(settings[:publishable_key], settings[:secret_key])
-      request.body = JSON.dump({ site_uuid: settings[:site_uuid], emails: import_data })
+      request.body = JSON.dump(
+        site_uuid: settings[:site_uuid],
+        emails: [email_payload(to, from, subject, html_body, personalization)]
+      )
       request.content_type = "application/json"
+      request
+    end
+
+    def perform_request(request)
       req_options = { use_ssl: BENTO_ENDPOINT.scheme == "https" }
 
-      response = Net::HTTP.start(BENTO_ENDPOINT.hostname, BENTO_ENDPOINT.port, req_options) do |http|
+      Net::HTTP.start(BENTO_ENDPOINT.hostname, BENTO_ENDPOINT.port, req_options) do |http|
         http.request(request)
       end
+    end
 
-      handle_response(response)
+    def email_payload(to, from, subject, html_body, personalization)
+      {
+        to: to,
+        from: from,
+        subject: subject,
+        html_body: html_body,
+        transactional: settings[:transactional],
+        personalizations: personalization
+      }
     end
 
     def handle_response(response)
       return response if response.is_a?(Net::HTTPSuccess)
 
-      raise DeliveryError, api_error_message(response)
+      raise DeliveryError, ResponseErrorMessage.new(response).to_s
+    end
+  end
+
+  # Builds a safe, user-facing exception message from Bento API responses.
+  class ResponseErrorMessage
+    def initialize(response)
+      @response = response
     end
 
-    def api_error_message(response)
+    def to_s
       status = [response.code, response.message].compact.join(" ")
       message = "Bento API request failed"
       message += " (#{status})" unless status.empty?
@@ -77,6 +103,8 @@ module BentoActionMailer
 
       message
     end
+
+    private
 
     def parse_api_error_message(body)
       return if body.nil? || body.empty?
@@ -135,5 +163,7 @@ module BentoActionMailer
       joined_messages = messages.compact.reject(&:empty?).join(", ")
       joined_messages unless joined_messages.empty?
     end
+
+    attr_reader :response
   end
 end

--- a/lib/bento_actionmailer.rb
+++ b/lib/bento_actionmailer.rb
@@ -1,6 +1,7 @@
 require "bento_actionmailer/version"
 require "bento_actionmailer/railtie" if defined? Rails
 
+require "json"
 require "net/http"
 require "uri"
 
@@ -56,6 +57,83 @@ module BentoActionMailer
       response = Net::HTTP.start(BENTO_ENDPOINT.hostname, BENTO_ENDPOINT.port, req_options) do |http|
         http.request(request)
       end
+
+      handle_response(response)
+    end
+
+    def handle_response(response)
+      return response if response.is_a?(Net::HTTPSuccess)
+
+      raise DeliveryError, api_error_message(response)
+    end
+
+    def api_error_message(response)
+      status = [response.code, response.message].compact.join(" ")
+      message = "Bento API request failed"
+      message += " (#{status})" unless status.empty?
+
+      api_message = parse_api_error_message(response.body)
+      message += ": #{api_message}" if api_message
+
+      message
+    end
+
+    def parse_api_error_message(body)
+      return if body.nil? || body.empty?
+
+      parsed_body = JSON.parse(body)
+      json_error_message(parsed_body)
+    rescue JSON::ParserError
+      body
+    end
+
+    def json_error_message(value)
+      case value
+      when Hash
+        simple_message(value["message"] || value["error"]) || errors_message(value["errors"])
+      when Array
+        errors_message(value)
+      end
+    end
+
+    def simple_message(message)
+      return if message.nil?
+
+      joined_message = Array(message).compact.join(", ")
+      joined_message unless joined_message.empty?
+    end
+
+    def errors_message(errors)
+      case errors
+      when String
+        errors
+      when Array
+        join_messages(errors.map { |error| error_message(error) })
+      when Hash
+        join_messages(errors.map { |field, messages| field_error_message(field, messages) })
+      end
+    end
+
+    def error_message(error)
+      case error
+      when String
+        error
+      when Hash
+        field_error_message(error["field"], error["message"] || error["detail"] || error["title"])
+      end
+    end
+
+    def field_error_message(field, message)
+      return if message.nil? || message.empty?
+
+      return message unless field && !field.empty?
+
+      "#{field}: #{Array(message).join(", ")}"
+    end
+
+    def join_messages(messages)
+      joined_messages = messages.compact.reject(&:empty?).join(", ")
+      joined_messages unless joined_messages.empty?
     end
   end
 end

--- a/lib/bento_actionmailer/railtie.rb
+++ b/lib/bento_actionmailer/railtie.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 module BentoActionMailer
+  # Registers the Bento delivery method with Action Mailer when Rails loads.
   class Railtie < Rails::Railtie
     initializer "bento_action_mailer.add_delivery_method", before: "action_mailer.set_configs" do
       ActiveSupport.on_load(:action_mailer) do

--- a/lib/bento_actionmailer/version.rb
+++ b/lib/bento_actionmailer/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module BentoActionMailer
-  VERSION = "0.0.1".freeze
+  VERSION = "0.0.1"
 end

--- a/test/bento/test_actionmailer.rb
+++ b/test/bento/test_actionmailer.rb
@@ -3,14 +3,14 @@
 require "test_helper"
 
 class FakeHttp
-  attr_reader :request
+  attr_reader :last_request
 
   def initialize(response)
     @response = response
   end
 
   def request(request)
-    @request = request
+    @last_request = request
     @response
   end
 end
@@ -26,7 +26,7 @@ class BentoActionMailerTest < Minitest::Test
     with_stubbed_bento_response(response) do |fake_http|
       assert_same response, send_test_mail
 
-      body = JSON.parse(fake_http.request.body)
+      body = JSON.parse(fake_http.last_request.body)
       assert_equal "site_test", body["site_uuid"]
       assert_equal "sender@example.com", body["emails"].first["from"]
     end
@@ -57,15 +57,8 @@ class BentoActionMailerTest < Minitest::Test
   end
 
   def test_send_mail_raises_joined_json_errors_from_failed_response
-    response = http_response(
-      Net::HTTPUnprocessableEntity,
-      "422",
-      "Unprocessable Entity",
-      "{\"errors\":[{\"field\":\"from\",\"message\":\"is not an approved author\"}]}"
-    )
-
     error = assert_raises(BentoActionMailer::DeliveryMethod::DeliveryError) do
-      with_stubbed_bento_response(response) do
+      with_stubbed_bento_response(unapproved_author_response) do
         send_test_mail
       end
     end
@@ -122,6 +115,16 @@ class BentoActionMailerTest < Minitest::Test
   def http_response(response_class, code, message, body)
     response = response_class.new("1.1", code, message)
     response.instance_variable_set(:@body, body)
+    response.instance_variable_set(:@read, true)
     response
+  end
+
+  def unapproved_author_response
+    http_response(
+      Net::HTTPUnprocessableEntity,
+      "422",
+      "Unprocessable Entity",
+      "{\"errors\":[{\"field\":\"from\",\"message\":\"is not an approved author\"}]}"
+    )
   end
 end

--- a/test/bento/test_actionmailer.rb
+++ b/test/bento/test_actionmailer.rb
@@ -2,12 +2,126 @@
 
 require "test_helper"
 
-class Bento::TestActionmailer < Minitest::Test
-  def test_that_it_has_a_version_number
-    refute_nil ::Bento::Actionmailer::VERSION
+class FakeHttp
+  attr_reader :request
+
+  def initialize(response)
+    @response = response
   end
 
-  def test_it_does_something_useful
-    assert false
+  def request(request)
+    @request = request
+    @response
+  end
+end
+
+class BentoActionMailerTest < Minitest::Test
+  def test_that_it_has_a_version_number
+    refute_nil ::BentoActionMailer::VERSION
+  end
+
+  def test_send_mail_returns_success_response
+    response = http_response(Net::HTTPOK, "200", "OK", "{\"success\":true}")
+
+    with_stubbed_bento_response(response) do |fake_http|
+      assert_same response, send_test_mail
+
+      body = JSON.parse(fake_http.request.body)
+      assert_equal "site_test", body["site_uuid"]
+      assert_equal "sender@example.com", body["emails"].first["from"]
+    end
+  end
+
+  def test_send_mail_raises_json_message_from_failed_response
+    response = http_response(Net::HTTPForbidden, "403", "Forbidden", "{\"message\":\"Site is not approved\"}")
+
+    error = assert_raises(BentoActionMailer::DeliveryMethod::DeliveryError) do
+      with_stubbed_bento_response(response) do
+        send_test_mail
+      end
+    end
+
+    assert_equal "Bento API request failed (403 Forbidden): Site is not approved", error.message
+  end
+
+  def test_send_mail_raises_json_error_from_failed_response
+    response = http_response(Net::HTTPForbidden, "403", "Forbidden", "{\"error\":\"Author is not approved\"}")
+
+    error = assert_raises(BentoActionMailer::DeliveryMethod::DeliveryError) do
+      with_stubbed_bento_response(response) do
+        send_test_mail
+      end
+    end
+
+    assert_equal "Bento API request failed (403 Forbidden): Author is not approved", error.message
+  end
+
+  def test_send_mail_raises_joined_json_errors_from_failed_response
+    response = http_response(
+      Net::HTTPUnprocessableEntity,
+      "422",
+      "Unprocessable Entity",
+      "{\"errors\":[{\"field\":\"from\",\"message\":\"is not an approved author\"}]}"
+    )
+
+    error = assert_raises(BentoActionMailer::DeliveryMethod::DeliveryError) do
+      with_stubbed_bento_response(response) do
+        send_test_mail
+      end
+    end
+
+    assert_equal "Bento API request failed (422 Unprocessable Entity): from: is not an approved author", error.message
+  end
+
+  def test_send_mail_falls_back_to_response_body_when_error_is_not_json
+    response = http_response(Net::HTTPForbidden, "403", "Forbidden", "Forbidden")
+
+    error = assert_raises(BentoActionMailer::DeliveryMethod::DeliveryError) do
+      with_stubbed_bento_response(response) do
+        send_test_mail
+      end
+    end
+
+    assert_equal "Bento API request failed (403 Forbidden): Forbidden", error.message
+  end
+
+  private
+
+  def send_test_mail
+    delivery_method.send(
+      :send_mail,
+      to: "recipient@example.com",
+      from: "sender@example.com",
+      subject: "Welcome",
+      html_body: "<p>Hello</p>"
+    )
+  end
+
+  def delivery_method
+    BentoActionMailer::DeliveryMethod.new(
+      publishable_key: "publishable_key",
+      secret_key: "secret_key",
+      site_uuid: "site_test"
+    )
+  end
+
+  def with_stubbed_bento_response(response)
+    fake_http = FakeHttp.new(response)
+
+    Net::HTTP.stub(:start, lambda do |host, port, options, &block|
+      assert_equal "app.bentonow.com", host
+      assert_equal 443, port
+      assert_equal({ use_ssl: true }, options)
+
+      block.call(fake_http)
+    end) do
+      yield fake_http
+    end
+  end
+
+  def http_response(response_class, code, message, body)
+    response = response_class.new("1.1", code, message)
+    response.instance_variable_set(:@body, body)
+    response
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
-require "bento/actionmailer"
+require "bento_actionmailer"
 
 require "minitest/autorun"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Raise `DeliveryError` when the Bento API returns a non-success response.
- Include the API's JSON `message`, `error`, or `errors` content in the exception message, along with the HTTP status.
- Replace the generated placeholder test with focused response handling coverage and keep RuboCop passing for the inspected files.

## Tests
- `BUNDLE_PATH=vendor/bundle bundle exec rake`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6af98905-d312-4832-9503-5b8c25ebd12f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6af98905-d312-4832-9503-5b8c25ebd12f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

